### PR TITLE
chore: main logo 이미지 로딩 우선순위 조정

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/x-icon" href="/f-univ.ico" />
+    <link rel="preload" as="image" href="/icons/_3D_logo.svg">
     <meta
       name="description"
       content="Front-end Developer를 꿈꾸는 대학생들이 한층 더 성장하는 기회!"


### PR DESCRIPTION
페이지 진입시 가장 먼저 보이게 되는 요소중 3d 로고의 로드 우선순위를 높여 깜빡임 현상을 방지합니다.

### AS-IS

<img width="870" alt="Screen Shot 2022-11-30 at 9 22 54 PM" src="https://user-images.githubusercontent.com/57053577/204795397-e8390972-f61c-40e0-bf64-c2ace886a61c.png">

### TO-BE

<img width="913" alt="Screen Shot 2022-11-30 at 9 20 49 PM" src="https://user-images.githubusercontent.com/57053577/204794958-995aa2de-38eb-4c8e-9437-f07cea82331d.png">
